### PR TITLE
Implement the Activate D-Bus method for primary click handling

### DIFF
--- a/src/app-indicator.c
+++ b/src/app-indicator.c
@@ -120,6 +120,7 @@ enum {
     CONNECTION_CHANGED,
     NEW_ICON_THEME_PATH,
     SCROLL_EVENT,
+    ACTIVATE_EVENT,
     LAST_SIGNAL
 };
 
@@ -624,6 +625,23 @@ app_indicator_class_init (AppIndicatorClass *klass)
                                       NULL, NULL,
                                       _application_service_marshal_VOID__INT_UINT,
                                       G_TYPE_NONE, 2, G_TYPE_INT, GDK_TYPE_SCROLL_DIRECTION);
+
+    /**
+     * AppIndicator::activate:
+     * @arg0: The #AppIndicator object
+     * @arg1: The x coordinate of the activation
+     * @arg2: The y coordinate of the activation
+     *
+     * Signaled when the #AppIndicator receives a primary activation event
+     * (e.g. left-click on the tray icon).
+     */
+    signals[ACTIVATE_EVENT] = g_signal_new (APP_INDICATOR_SIGNAL_ACTIVATE_EVENT,
+                                      G_TYPE_FROM_CLASS(klass),
+                                      G_SIGNAL_RUN_LAST,
+                                      G_STRUCT_OFFSET (AppIndicatorClass, activate_event),
+                                      NULL, NULL,
+                                      _application_service_marshal_VOID__INT_INT,
+                                      G_TYPE_NONE, 2, G_TYPE_INT, G_TYPE_INT);
 
     /* DBus interfaces */
     if (item_node_info == NULL) {
@@ -1192,7 +1210,23 @@ bus_method_call (GDBusConnection * connection, const gchar * sender,
     AppIndicatorPrivate * priv = app_indicator_get_instance_private(app);
     GVariant * retval = NULL;
 
-    if (g_strcmp0(method, "Scroll") == 0) {
+    if (g_strcmp0(method, "Activate") == 0) {
+        gint x, y;
+        g_variant_get(params, "(ii)", &x, &y);
+
+        if (g_signal_has_handler_pending(app, signals[ACTIVATE_EVENT], 0, FALSE)) {
+            g_signal_emit(app, signals[ACTIVATE_EVENT], 0, x, y);
+            g_dbus_method_invocation_return_value(invocation, retval);
+        } else {
+            /* No handler connected — return error so the panel falls back
+             * to showing the context menu for backward compatibility. */
+            g_dbus_method_invocation_return_error(invocation,
+                G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD,
+                "No handler for Activate");
+        }
+        return;
+
+    } else if (g_strcmp0(method, "Scroll") == 0) {
         GdkScrollDirection direction;
         gint delta;
         const gchar *orientation;

--- a/src/app-indicator.h
+++ b/src/app-indicator.h
@@ -119,6 +119,7 @@ G_BEGIN_DECLS
 #define APP_INDICATOR_SIGNAL_CONNECTION_CHANGED  "connection-changed"
 #define APP_INDICATOR_SIGNAL_NEW_ICON_THEME_PATH "new-icon-theme-path"
 #define APP_INDICATOR_SIGNAL_SCROLL_EVENT        "scroll-event"
+#define APP_INDICATOR_SIGNAL_ACTIVATE_EVENT      "activate"
 
 /**
  * AppIndicatorCategory:
@@ -169,6 +170,7 @@ typedef struct _AppIndicatorClass   AppIndicatorClass;
  * @new_label: Slot for #AppIndicator::new-label.
  * @connection_changed: Slot for #AppIndicator::connection-changed.
  * @scroll_event: Slot for #AppIndicator::scroll-event
+ * @activate_event: Slot for #AppIndicator::activate
  * @app_indicator_reserved_ats: Reserved for future use.
  * @fallback: Function that gets called to make a #GtkStatusIcon when
  *            there is no Application Indicator area available.
@@ -212,6 +214,11 @@ struct _AppIndicatorClass {
     void (* scroll_event)           (AppIndicator * indicator,
                                      gint                  delta,
                                      GdkScrollDirection direction,
+                                     gpointer          user_data);
+
+    void (* activate_event)         (AppIndicator * indicator,
+                                     gint                  x,
+                                     gint                  y,
                                      gpointer          user_data);
 
     void (*app_indicator_reserved_ats)(void);

--- a/src/notification-item.xml
+++ b/src/notification-item.xml
@@ -20,6 +20,10 @@
 		<property name="XAyatanaOrderingIndex" type="u" access="read" />
 
 <!-- Methods -->
+		<method name="Activate">
+			<arg type="i" name="x" direction="in" />
+			<arg type="i" name="y" direction="in" />
+		</method>
 		<method name="Scroll">
 			<arg type="i" name="delta" direction="in" />
 			<arg type="s" name="orientation" direction="in" />


### PR DESCRIPTION
Handle the org.kde.StatusNotifierItem Activate() method that KDE Plasma calls on left-click. When a signal handler is connected, emit the "activate" GObject signal and return success. When no handler is connected, return an error so the panel falls back to showing the context menu for backward compatibility.

This fixes the dual menu+toggle issue for applications like Onboard that need left-click to perform a custom action instead of showing the context menu.

Co-authored-by: Z.AI GLM

--------------------------

Why did I need this?

The Onboard https://github.com/onboard-osk/onboard virtual on-screen keyboard uses AppIndicator and can easily be switched to using Ayatana:

```diff
Description: Switch to AyatanaAppIndicator.
Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>

--- a/Onboard/Indicator.py
+++ b/Onboard/Indicator.py
@@ -294,7 +294,7 @@
         BackendBase.__init__(self, menu)
 
         try:
-            from gi.repository import AppIndicator3 as AppIndicator
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator
         except ImportError as ex:
             raise RuntimeError(ex)
 
@@ -350,7 +350,7 @@
 
     def _set_indicator_active(self, active):
         try:
-            from gi.repository import AppIndicator3 as AppIndicator
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator
         except ImportError:
             pass
         else:
--- a/Onboard/Version.py
+++ b/Onboard/Version.py
@@ -33,9 +33,9 @@
     except ValueError:
         pass
 
-    # AppIndicator3 is not required
+    # AyatanaAppIndicator3 is not required
     try:
-        gi.require_version('AppIndicator3', '0.1')
+        gi.require_version('AyatanaAppIndicator3', '0.1')
     except ValueError:
         pass
 ```

ROSA Linux package of onboard has used such patch for a long time.

Onboard can draw a tray icon either via the obsolete GtkStatusIcon, or via AppIndicator. GtkStatusIcon draws a pixelled, not high quality icon. AppIdincator draws a good icon.

Onboard tray icon opens and hides the keyboard via a left click (by a mouse or a finger on touch screens). With Ayatana AppIndicator, **both** a context menu and hide/show were triggered on right click. With this patch for AppIndicator it became possible to:

- hide/show the keyboard via left click
- show a context menu via right click

The patch for onboard is the following (it just removes hacks and simplifies its code):

```diff
diff --git a/Onboard/Indicator.py b/Onboard/Indicator.py
index ff620c3d..44891abe 100644
--- a/Onboard/Indicator.py
+++ b/Onboard/Indicator.py
@@ -25,11 +25,6 @@ import os
 import shutil
 import subprocess
 
-try:
-    import dbus
-except ImportError:
-    pass
-
 from Onboard.Version import require_gi_versions
 require_gi_versions()
 from gi.repository import GObject, Gtk
@@ -313,10 +308,6 @@ class BackendAppIndicator(BackendBase):
 
     _indicator = None
 
-    STATUSNOTIFIER_OBJECT = "/org/ayatana/NotificationItem/Onboard"
-    STATUSNOTIFIER_IFACE = "org.kde.StatusNotifierItem"
-    ACTIVATE_METHOD = "Activate"
-
     def __init__(self, menu):
         BackendBase.__init__(self, menu)
 
@@ -336,42 +327,16 @@ class BackendAppIndicator(BackendBase):
         self._indicator.set_secondary_activate_target(
             menu._menu.get_children()[0])
 
-        if "dbus" in globals():
-            # Watch left-click Activate() calls on desktops that send them
-            # (KDE Plasma). There is still "No such method 'Activate'" in
-            # AppIndicator.
-            try:
-                self._bus = dbus.SessionBus()
-            except dbus.exceptions.DBusException as ex:
-                _logger.warning("D-Bus session bus unavailable, "
-                                "no left-click Activate() for AppIndicator: " +
-                                unicode_str(ex))
-            else:
-                try:
-                    self._bus.add_match_string(
-                        "type='method_call',"
-                        "eavesdrop=true,"
-                        "path='{}',"
-                        "interface='{}',"
-                        "member='{}'"
-                        .format(self.STATUSNOTIFIER_OBJECT,
-                                self.STATUSNOTIFIER_IFACE,
-                                self.ACTIVATE_METHOD))
-                    self._bus.add_message_filter(self._on_activate_method)
-                except dbus.exceptions.DBusException as ex:
-                    _logger.warning("Failed to setup D-Bus match rule, "
-                                    "no left-click Activate() for AppIndicator: " +
-                                    unicode_str(ex))
+        # Connect to the "activate" signal for left-click handling.
+        # The library handles the D-Bus Activate method and emits this
+        # signal when the tray icon is left-clicked (e.g. in KDE Plasma).
+        self._indicator.connect("activate",
+                                lambda indicator, x, y:
+                                menu.on_show_keyboard_toggle())
 
     def cleanup(self):
         pass
 
-    def _on_activate_method(self, bus, message):
-        if message.get_path() == self.STATUSNOTIFIER_OBJECT and \
-           message.get_member() == self.ACTIVATE_METHOD:
-            self._menu.on_show_keyboard_toggle()
-        return dbus.connection.HANDLER_RESULT_NOT_YET_HANDLED
-
     def set_visible(self, visible):
         self._set_indicator_active(visible)

```

I will try to upstreamize it into Onboard (https://github.com/onboard-osk/onboard) if this PR is merged here.